### PR TITLE
upgrade dependency on bcpkix-jdk15on to fix vulnerability. fixes #4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.47</version>
+			<version>1.54</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Built successfully after following the instructions about the Jurisdiction Policy Files on Maven 3 with Java 8.