### PR TITLE
Update bouncycastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.71</version>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>1.73</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This updates bouncycastle and defines some maven plugins.

Indirectly it updates also the depdendency to Java 8. Java8 is the oldest, still supported Version of java
See https://endoflife.date/java 

